### PR TITLE
pkg_resources library is replaced with importlib.resources to address deprecation

### DIFF
--- a/cbfv/composition.py
+++ b/cbfv/composition.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import tqdm
 import os
-import pkg_resources
+from importlib.resources import files
 # dirpath = os.getcwd()
 
 class CompositionError(Exception):
@@ -235,9 +235,10 @@ def generate_features(df, elem_prop='oliynyk',
     #             + '/CBFV/element_properties/'
     #             + elem_prop
     #             + '.csv')
-    cbfv_path = pkg_resources.resource_stream(__name__, f'element_properties/{elem_prop}.csv')
-
-    elem_props = pd.read_csv(cbfv_path)
+    cbfv_files = files(__name__.split('.')[0])
+    cbfv_path = cbfv_files.joinpath('element_properties', f'{elem_prop}.csv')
+    with cbfv_path.open('r') as f:
+        elem_props = pd.read_csv(f)
 
     elem_props.index = elem_props['element'].values
     elem_props.drop(['element'], inplace=True, axis=1)


### PR DESCRIPTION
The pkg_resources package is deprecated as an API and is slated for removal as early as November 30, 2025. Users should transition to modern alternatives provided by the Python standard library, primarily importlib.resources and importlib.metadata, which offer more efficient and integrated functionality. 
— Gemini